### PR TITLE
Event polling is disabled when the event bar is not part of the layout

### DIFF
--- a/publisher-web/app/assets/js/layout.js
+++ b/publisher-web/app/assets/js/layout.js
@@ -114,10 +114,12 @@ require ([
     	});
     }
     
-    // Start polling the server for events:
-    setTimeout (function () {
-    	pollEvents ();
-    });
+    // Start polling the server for events if the event bar is available in the layout:
+    if (dom.byId ('event-bar')) {
+    	setTimeout (function () {
+    		pollEvents ();
+    	});
+    }
     
     // =========================================================================
     // Update task list:

--- a/publisher-web/app/views/layout/application.scala.html
+++ b/publisher-web/app/views/layout/application.scala.html
@@ -38,7 +38,7 @@
 				</div>
 				
 				@* Top links: *@
-				<ul class="nav navbar-top-links navbar-right">
+				<ul class="nav navbar-top-links navbar-right" id="event-bar">
 					<li class="dropdown" id="event-dropdown-notifications">
 						<a href="#" class="dropdown-toggle" data-toggle="dropdown" title="Nieuwe meldingen"><span class="glyphicon glyphicon-bell"></span> <span class="badge js-badge">1</span> <b class="caret"></b></a>
 						<ul class="js-list dropdown-menu dropdown-messages">


### PR DESCRIPTION
(currently this is the case for the login page).
