### PR TITLE
Deploy the Play app as a Maven artifact

### DIFF
--- a/publisher-web/build.sbt
+++ b/publisher-web/build.sbt
@@ -1,6 +1,6 @@
 name := """publisher-web"""
 
-version := "1.0-SNAPSHOT"
+version := "0.0.1-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 

--- a/publisher-web/pom.xml
+++ b/publisher-web/pom.xml
@@ -120,6 +120,31 @@
     			</executions>
     			
     		</plugin>
+    		
+    		<!-- Deply the Play deliverable as a Maven artifact: -->
+    		<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-play-app</id>
+						<phase>package</phase>
+						<goals>
+							<goal>attach-artifact</goal>
+						</goals>
+						<configuration>
+							<artifacts>
+								<artifact>
+									<file>target/universal/${project.artifactId}-${project.version}.zip</file>
+									<type>zip</type>
+									<classifier>app</classifier>
+								</artifact>
+							</artifacts>
+						</configuration>
+					</execution>
+				</executions>
+    		</plugin>
+    		
     	</plugins>
     </build>
 	


### PR DESCRIPTION
The package Play app (zip file) is added as a Maven artifact (type: zip, classifier: app).

The project version in build.sbt didn't match the version of the POM's. To make this work, the versions have to match. Otherwise the filename of the zip-file can't be composed using ${project.version}.