### PR TITLE
Zookeeper registration for web project

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,6 +16,9 @@ Vagrant.configure(2) do |config|
 	
 	# Forward the zookeeper port:
 	config.vm.network "forwarded_port", guest: 2181, host: 2181
+	
+	# Forward the exhibitor port:
+	config.vm.network "forwarded_port", guest:8081, host: 8081
 
 	# Configure VirtualBox:
   	config.vm.provider "virtualbox" do |vb|

--- a/publisher-web/app/Global.java
+++ b/publisher-web/app/Global.java
@@ -1,8 +1,24 @@
+import java.io.IOException;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.nio.charset.Charset;
 import java.text.ParseException;
+import java.util.Enumeration;
 import java.util.Locale;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import models.Domain;
 import nl.idgis.publisher.domain.web.Filter;
+
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.KeeperException.Code;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.ZooDefs.Ids;
+import org.apache.zookeeper.ZooKeeper;
+
 import play.Application;
 import play.GlobalSettings;
 import play.Logger;
@@ -15,8 +31,14 @@ import play.mvc.Result;
 import play.mvc.Results;
 import views.html.exceptions.domainAccessException;
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 public class Global extends GlobalSettings {
 
+	private ZooKeeper zooKeeper;
+	private AtomicBoolean zooKeeperRegistered = new AtomicBoolean (false);
+	
 	@Override
 	public void onStart (final Application application) {
 		Formatters.register (Filter.class, new Formatters.SimpleFormatter<Filter> () {
@@ -35,6 +57,148 @@ public class Global extends GlobalSettings {
 				return Json.stringify (Json.toJson (filter));
 			}
 		});
+		
+		// Create a Zookeeper connection:
+		final String zooKeeperHosts = application.configuration ().getString ("zooKeeper.hosts", null);
+		if (zooKeeperHosts != null) {
+			final int zooKeeperTimeout = application.configuration ().getInt ("zooKeeper.timeoutInMillis", 10000);
+			
+			final String applicationDomain = application.configuration ().getString ("application.domain", "localhost");
+			final int httpPort = application.configuration ().getInt ("http.port", 9000);
+			final String httpAddress = application.configuration ().getString ("http.address", "0.0.0.0");
+			final String destinationIp;
+
+			Logger.debug ("Http address: " + httpAddress);
+			
+			if ("0.0.0.0".equals (httpAddress)) {
+				destinationIp = getPublicIp ();
+			} else {
+				destinationIp = httpAddress;
+			}
+
+			if (destinationIp == null) {
+				Logger.error ("Failed to determine the public IP of this server, skipping Zookeeper registration.");
+			} else {
+				final ObjectNode configuration = Json.newObject ();
+				final ArrayNode proxy = configuration.putArray ("proxy");
+				final ObjectNode proxyLine = proxy.addObject ();
+	
+				proxyLine.put ("type", "http");
+				proxyLine.put ("path", "/");
+				proxyLine.put ("domain", applicationDomain);
+				proxyLine.put ("destination", "http://" + destinationIp + ":" + httpPort + "/");
+				
+				final String zooKeeperConfiguration = Json.stringify (configuration);
+				
+				Logger.info ("Connecting to ZooKeeper cluster: " + zooKeeperHosts);
+				Logger.info ("Sending ZooKeeper configuration: " + configuration);
+				
+				try {
+					zooKeeper = new ZooKeeper (zooKeeperHosts, zooKeeperTimeout, (event) -> handleZooKeeperEvent (event, applicationDomain, zooKeeperConfiguration), false);
+				} catch (IOException e) {
+					zooKeeper = null;
+					Logger.error ("Failed to connect to a ZooKeeper instance", e);
+					throw new RuntimeException (e);
+				}
+			}
+		}
+	}
+	
+	private String getPublicIp () {
+		try {
+			final Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces ();
+			
+			while (networkInterfaces.hasMoreElements ()) {
+				final NetworkInterface networkInterface = networkInterfaces.nextElement ();
+				
+				// Skip loopback point-to-point interfaces and interfaces that are not up:
+				if (networkInterface.isLoopback () || networkInterface.isPointToPoint () || !networkInterface.isUp ()) {
+					continue;
+				}
+				
+				final Enumeration<InetAddress> addresses = networkInterface.getInetAddresses ();
+				while (addresses.hasMoreElements ()) {
+					final InetAddress address = addresses.nextElement ();
+					
+					if (address.isLoopbackAddress () || address.isMulticastAddress ()) {
+						continue;
+					}
+					
+					if (address instanceof Inet4Address) {
+						return address.getHostAddress ();
+					}
+				}
+			}
+			
+			return null;
+		} catch (SocketException e) {
+			throw new RuntimeException ("Failed to determine public IP of this server.");
+		}
+	}
+
+	@Override
+	public void onStop (final Application app) {
+		if (zooKeeper != null) {
+			try {
+				zooKeeper.close ();
+			} catch (InterruptedException e) {
+				Logger.warn ("Failed to close the ZooKeeper connection", e);
+			}
+		}
+	}
+	
+	private void handleZooKeeperEvent (final WatchedEvent event, final String applicationDomain, final String configuration) {
+		switch (event.getState ()) {
+		case AuthFailed:
+			break;
+		case ConnectedReadOnly:
+			break;
+		case Disconnected:
+			break;
+		case Expired:
+			break;
+		case SaslAuthenticated:
+			break;
+		case SyncConnected:
+			registerApplication (applicationDomain, configuration);
+			break;
+		default:
+			break;
+		}
+		
+	}
+	
+	private void registerApplication (final String applicationDomain, final String configuration) {
+		
+		if (!zooKeeperRegistered.compareAndSet (false, true)) {
+			return;
+		}
+		
+		try {
+			createPublicPath ("/services");
+			createPublicPath ("/services/web");
+			createPublicPath ("/services/web/domains");
+			createPublicPath ("/services/web/domains/" + applicationDomain);
+			
+			final String zooKeeperPath = zooKeeper.create (String.format ("/services/web/domains/%s/", applicationDomain), configuration.getBytes (Charset.forName ("UTF-8")), Ids.READ_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL);
+			
+			Logger.info ("Registered at path: " + zooKeeperPath);
+		} catch (KeeperException | InterruptedException e) {
+			Logger.error ("Failed to register this application with ZooKeeper", e);
+			throw new RuntimeException (e);
+		}
+	}
+	
+	private void createPublicPath (final String path) throws InterruptedException, KeeperException {
+		try {
+			if (zooKeeper.exists (path, null) == null) {
+				zooKeeper.create (path, null, Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+			}
+		} catch (KeeperException e) {
+			if (!Code.NODEEXISTS.equals (e.code ())) {
+				throw e;
+			}
+		}
 	}
 	
 	@Override

--- a/publisher-web/build.sbt
+++ b/publisher-web/build.sbt
@@ -18,7 +18,7 @@ libraryDependencies ++= Seq(
   "nl.idgis.publisher" % "publisher-domain" % (xml.XML.loadFile("pom.xml") \\ "project" \ "parent" \ "version" ).map (_.text).head,
   "com.typesafe.akka" %% "akka-remote" % "2.3.3",
   "org.pegdown" % "pegdown" % "1.5.0",
-  "org.apache.zookeeper" % "zookeeper", "3.4.5"
+  "org.apache.zookeeper" % "zookeeper" % "3.4.5"
 )
 
 includeFilter in (Assets, LessKeys.less) := "*.less"

--- a/publisher-web/build.sbt
+++ b/publisher-web/build.sbt
@@ -17,7 +17,8 @@ libraryDependencies ++= Seq(
   "org.webjars" % "dojo" % "1.10.0",
   "nl.idgis.publisher" % "publisher-domain" % (xml.XML.loadFile("pom.xml") \\ "project" \ "parent" \ "version" ).map (_.text).head,
   "com.typesafe.akka" %% "akka-remote" % "2.3.3",
-  "org.pegdown" % "pegdown" % "1.5.0"
+  "org.pegdown" % "pegdown" % "1.5.0",
+  "org.apache.zookeeper" % "zookeeper", "3.4.5"
 )
 
 includeFilter in (Assets, LessKeys.less) := "*.less"

--- a/publisher-web/build.sbt
+++ b/publisher-web/build.sbt
@@ -18,7 +18,7 @@ libraryDependencies ++= Seq(
   "nl.idgis.publisher" % "publisher-domain" % (xml.XML.loadFile("pom.xml") \\ "project" \ "parent" \ "version" ).map (_.text).head,
   "com.typesafe.akka" %% "akka-remote" % "2.3.3",
   "org.pegdown" % "pegdown" % "1.5.0",
-  "org.apache.zookeeper" % "zookeeper" % "3.4.5"
+  "org.apache.zookeeper" % "zookeeper" % "3.4.5" exclude("javax.jms", "jms") exclude("com.sun.jdmk", "jmxtools") exclude("com.sun.jmx", "jmxri")
 )
 
 includeFilter in (Assets, LessKeys.less) := "*.less"

--- a/publisher-web/conf/application.conf
+++ b/publisher-web/conf/application.conf
@@ -123,3 +123,12 @@ publisher {
 		format = "application/openlayers"
 	}
 }
+
+# ------------------------------------------------------------------------------ 
+# Zookeeper configuration:
+# ------------------------------------------------------------------------------
+application.domain = "localhost"
+
+# By default, connect to a Zookeeper instance running on localhost:
+zooKeeper.hosts = "localhost:2181"
+zooKeeper.timeoutInMillis = 10000

--- a/publisher-web/conf/application.conf
+++ b/publisher-web/conf/application.conf
@@ -129,6 +129,8 @@ publisher {
 # ------------------------------------------------------------------------------
 application.domain = "localhost"
 
-# By default, connect to a Zookeeper instance running on localhost:
-zooKeeper.hosts = "localhost:2181"
+# ZooKeeper host. When set, the application connects to and registers itself with the hosts in this parameter (comma separated):
+# zooKeeper.hosts = "localhost:2181"
+
+# ZooKeeper timeout. The timeout on the ZooKeper connection before the next server is tried.
 zooKeeper.timeoutInMillis = 10000


### PR DESCRIPTION
When the ``zooKeeper.hosts`` configuration parameter is set, the web application registers itself with a ZooKeeper cluster as a proxy. The application controls its domain using the ``application.domain`` parameter and uses ``http.address`` and ``http.port`` to configure the proxy.