### PR TITLE
workaround for '.' in workspace name

### DIFF
--- a/publisher-service/src/main/java/nl/idgis/publisher/service/geoserver/rest/DefaultGeoServerRest.java
+++ b/publisher-service/src/main/java/nl/idgis/publisher/service/geoserver/rest/DefaultGeoServerRest.java
@@ -317,7 +317,7 @@ public class DefaultGeoServerRest implements GeoServerRest {
 	}	
 	
 	private String getWorkspacePath(String workspaceId) {
-		return getWorkspacesPath() + "/" + workspaceId;
+		return getWorkspacesPath() + "/" + workspaceId.replace(".", "%2E");
 	}
 	
 	private String getWorkspacePath(Workspace workspace) {

--- a/publisher-service/src/test/java/nl/idgis/publisher/service/geoserver/rest/DefaultGeoServerRestTest.java
+++ b/publisher-service/src/test/java/nl/idgis/publisher/service/geoserver/rest/DefaultGeoServerRestTest.java
@@ -534,4 +534,21 @@ public class DefaultGeoServerRestTest {
 		allCoverages = service.getCoverages(workspace).get();
 		assertTrue(allCoverages.isEmpty());
 	}
+	
+	@Test
+	public void testDeleteWorkspace() throws Exception {
+		assertTrue(service.getWorkspaces().get().isEmpty());
+		
+		String workspaceName = "it.geosolutions";
+		
+		Workspace workspace = new Workspace(workspaceName);
+		service.postWorkspace(workspace).get();		
+		
+		List<Workspace> workspaces = service.getWorkspaces().get();
+		assertFalse(workspaces.isEmpty());
+		assertEquals(workspaceName, workspaces.get(0).getName());
+		
+		service.deleteWorkspace(workspace).get();		
+		assertTrue(service.getWorkspaces().get().isEmpty());
+	}
 }


### PR DESCRIPTION
The default geoserver configuration contains a workspace named 'it.geosolutions'. Deleting this workspace is not possible without this workaround.