### PR TITLE
job creator now ignores datasets based on an unavailable source dataset

### DIFF
--- a/publisher-database/src/main/resources/nl/idgis/publisher/database/rev057.sql
+++ b/publisher-database/src/main/resources/nl/idgis/publisher/database/rev057.sql
@@ -1,0 +1,47 @@
+
+drop view publisher.dataset_status;
+
+-- source_dataset_available column added
+create view publisher.dataset_status as 
+select 
+	d.id,
+	d.identification,
+	exists (
+		select * from publisher.last_import_job
+		where dataset_id = d.id) imported,
+	exists (
+		select * from publisher.dataset_column_diff
+		where dataset_id = d.id) columns_changed,	
+	exists (
+		select * from publisher.source_dataset_column_diff
+		where dataset_id = d.id) source_dataset_columns_changed,
+	(	
+		select sdv0.revision != sdv1.revision
+		from publisher.last_import_job lij
+		join publisher.import_job ij on ij.job_id = lij.job_id
+		join publisher.source_dataset_version sdv0 on sdv0.id = ij.source_dataset_version_id
+		join publisher.last_source_dataset_version lsdv on lsdv.dataset_id = ij.dataset_id
+		join publisher.source_dataset_version sdv1 on sdv1.id = lsdv.source_dataset_version_id
+		where lij.dataset_id = d.id) source_dataset_revision_changed,
+	(
+		select sdv.source_dataset_id != d.source_dataset_id		
+		from publisher.last_import_job lij
+		join publisher.import_job ij on ij.job_id = lij.job_id
+		join publisher.source_dataset_version sdv on sdv.id = ij.source_dataset_version_id
+		where lij.dataset_id = d.id
+	) source_dataset_changed,
+	(
+		select ij.filter_conditions != d.filter_conditions
+		from publisher.last_import_job lij
+		join publisher.import_job ij on ij.job_id = lij.job_id
+		where lij.dataset_id = d.id		
+	) filter_condition_changed,
+	(
+		select sdv.type != 'UNAVAILABLE'
+		from publisher.last_source_dataset_version lsdv
+		join publisher.source_dataset_version sdv on sdv.id = lsdv.source_dataset_version_id
+		where lsdv.dataset_id = d.id
+	) source_dataset_available
+from publisher.dataset d;
+
+insert into publisher.version(id) values(57);

--- a/publisher-service/src/main/java/nl/idgis/publisher/job/creator/Creator.java
+++ b/publisher-service/src/main/java/nl/idgis/publisher/job/creator/Creator.java
@@ -124,12 +124,13 @@ public class Creator extends UntypedActor {
 	
 	private CompletableFuture<Object> handleCreateImportJobs(CreateImportJobs msg) {
 		return db.query().from(datasetStatus)
-			.where(datasetStatus.imported.isFalse()
+			.where(datasetStatus.sourceDatasetAvailable.isTrue().and(
+				datasetStatus.imported.isFalse()
 				.or(datasetStatus.sourceDatasetRevisionChanged.isTrue())
 				.or(datasetStatus.sourceDatasetColumnsChanged.isTrue())
 				.or(datasetStatus.columnsChanged.isTrue())
 				.or(datasetStatus.sourceDatasetChanged.isTrue())
-				.or(datasetStatus.filterConditionChanged.isTrue()))
+				.or(datasetStatus.filterConditionChanged.isTrue())))
 			.list(datasetStatus.identification).thenCompose(datasetIds ->
 				forEach(datasetIds.list().stream(), datasetId -> f.ask(jobManager, new CreateImportJob(datasetId))));
 	}

--- a/publisher-service/src/test/java/nl/idgis/publisher/job/creator/CreatorTest.java
+++ b/publisher-service/src/test/java/nl/idgis/publisher/job/creator/CreatorTest.java
@@ -8,6 +8,8 @@ import org.junit.Test;
 
 import akka.actor.ActorRef;
 
+import nl.idgis.publisher.domain.SourceDatasetType;
+
 import nl.idgis.publisher.AbstractServiceTest;
 import nl.idgis.publisher.job.creator.messages.CreateHarvestJobs;
 import nl.idgis.publisher.job.creator.messages.CreateImportJobs;
@@ -15,6 +17,8 @@ import nl.idgis.publisher.job.manager.messages.GetHarvestJobs;
 import nl.idgis.publisher.job.manager.messages.GetImportJobs;
 import nl.idgis.publisher.protocol.messages.Ack;
 import nl.idgis.publisher.utils.TypedList;
+
+import static nl.idgis.publisher.database.QSourceDatasetVersion.sourceDatasetVersion;
 
 public class CreatorTest extends AbstractServiceTest {
 	
@@ -41,5 +45,18 @@ public class CreatorTest extends AbstractServiceTest {
 		assertFalse(f.ask(jobManager, new GetImportJobs(), TypedList.class).get().iterator().hasNext());
 		f.ask(creator, new CreateImportJobs(), Ack.class).get();		
 		assertTrue(f.ask(jobManager, new GetImportJobs(), TypedList.class).get().iterator().hasNext());
+	}
+	
+	@Test
+	public void testImportJobUnavailableSourceDataset() throws Exception {
+		insertDataset();
+		
+		update(sourceDatasetVersion)
+			.set(sourceDatasetVersion.type, SourceDatasetType.UNAVAILABLE.name())
+			.execute();
+		
+		assertFalse(f.ask(jobManager, new GetImportJobs(), TypedList.class).get().iterator().hasNext());
+		f.ask(creator, new CreateImportJobs(), Ack.class).get();		
+		assertFalse(f.ask(jobManager, new GetImportJobs(), TypedList.class).get().iterator().hasNext());
 	}
 }


### PR DESCRIPTION
Without this fix the job creator repeatedly requests the job manager to create import jobs for datasets  based on an unavailable source dataset. The job manager (correctly) fails to honor such requests, resulting in an error in the log. 

Because of the repeating nature of the job creation process this pollutes the log file to such extend that these errors make up for a large portion of the log, preventing investigation of other issues.