### PR TITLE
null check added

### DIFF
--- a/publisher-service/src/main/java/nl/idgis/publisher/loader/AbstractLoaderSession.java
+++ b/publisher-service/src/main/java/nl/idgis/publisher/loader/AbstractLoaderSession.java
@@ -174,7 +174,7 @@ public abstract class AbstractLoaderSession<T extends ImportJobInfo, U extends S
 					} else {
 						log.warning("unexpected sequence number: {}, expected: {}", seq, lastSeq + 1);
 					}
-				} else if(msg instanceof ReceiveTimeout && retries > 0) {
+				} else if(msg instanceof ReceiveTimeout && retries > 0 && lastItemSender != null) {
 					log.warning("timemout, requesting retry");
 					lastItemSender.tell(new NextItem(lastSeq + 1), getSelf());
 					retries--;


### PR DESCRIPTION
Retrying is only possible when we previously received an item, otherwise
we don't have a reference to the producer within the provider yet. We
need this reference to ask for a retry.