### PR TITLE
Include a single link to the download service

### DIFF
--- a/publisher-commons/src/main/java/nl/idgis/publisher/metadata/MetadataDocument.java
+++ b/publisher-commons/src/main/java/nl/idgis/publisher/metadata/MetadataDocument.java
@@ -618,7 +618,9 @@ public class MetadataDocument {
 		String parentPath = xmlDocument.addNode(namespaces, getDigitalTransferOptionsPath(), new String[]{"gmd:offLine"}, "gmd:onLine/gmd:CI_OnlineResource");
 		xmlDocument.addNode(namespaces, parentPath, "gmd:linkage/gmd:URL", linkage);
 		xmlDocument.addNode(namespaces, parentPath, "gmd:protocol/gco:CharacterString", protocol);
-		xmlDocument.addNode(namespaces, parentPath, "gmd:name/gco:CharacterString", name);
+		if(name != null) {
+			xmlDocument.addNode(namespaces, parentPath, "gmd:name/gco:CharacterString", name);
+		}
 	}
 	
 	private XPathHelper xpath() {

--- a/publisher-metadata/app/controllers/DatasetMetadata.java
+++ b/publisher-metadata/app/controllers/DatasetMetadata.java
@@ -259,7 +259,17 @@ public class DatasetMetadata extends AbstractMetadata {
 						publishedService.content,
 						environment.identification,
 						environment.url,
-						publishedServiceDataset.layerName);		
+						publishedServiceDataset.layerName);
+				
+				if(!serviceTuples.isEmpty()) {
+					config.getDownloadUrlPrefix().ifPresent(downloadUrlPrefix -> {
+						try {
+							metadataDocument.addServiceLinkage(downloadUrlPrefix + fileIdentifier, "download", null);
+						} catch(NotFound nf) {
+							throw new RuntimeException(nf);
+						}
+					});
+				}
 				
 				for(Tuple serviceTuple : serviceTuples) {
 					JsonNode serviceInfo = Json.parse(serviceTuple.get(publishedService.content));
@@ -268,14 +278,6 @@ public class DatasetMetadata extends AbstractMetadata {
 					String environmentId = serviceTuple.get(environment.identification);
 					String scopedName = serviceTuple.get(publishedServiceDataset.layerName);
 					String environmentUrl = serviceTuple.get(environment.url);
-					
-					config.getDownloadUrlPrefix().ifPresent(downloadUrlPrefix -> {
-						try {
-							metadataDocument.addServiceLinkage(downloadUrlPrefix + fileIdentifier, "download", serviceTuple.get(publishedServiceDataset.layerName));
-						} catch(NotFound nf) {
-							throw new RuntimeException(nf);
-						}
-					});
 					
 					// we only automatically generate browseGraphics 
 					// when none where provided by the source. 


### PR DESCRIPTION
Previously multiple links where included when the dataset was used in
multiple service + layers combinations.

fixes: IDgis/geoportaal-test#272