### PR TITLE
skip empty blobs

### DIFF
--- a/publisher-provider/publisher-provider-app/src/main/java/nl/idgis/publisher/provider/database/DatabaseCursor.java
+++ b/publisher-provider/publisher-provider-app/src/main/java/nl/idgis/publisher/provider/database/DatabaseCursor.java
@@ -52,11 +52,15 @@ public class DatabaseCursor extends StreamCursor<ResultSet, Records> {
 		if(columnInfo.getType() == Type.GEOMETRY) {
 			if(value instanceof Blob) {
 				Blob blob = (Blob)value;
-				if(blob.length() > Integer.MAX_VALUE) {
-					log.error("blob value too large: {}", blob.length());
+				long blobLength = blob.length();
+				if(blobLength > Integer.MAX_VALUE) {
+					log.error("blob value too large: {}", blobLength);
+					return null;
+				} if(blobLength == 0) { // known to be returned by SDE.ST_ASBINARY on empty geometries
+					log.error("empty blob");
 					return null;
 				} else {
-					return new WKBGeometry(blob.getBytes(1l, (int)blob.length()));
+					return new WKBGeometry(blob.getBytes(1l, (int)blobLength));
 				}
 			} else {
 				log.error("unsupported value: {}", value.getClass().getCanonicalName());

--- a/publisher-service/src/main/java/nl/idgis/publisher/harvester/sources/ProviderFetchVectorDatasetInitiator.java
+++ b/publisher-service/src/main/java/nl/idgis/publisher/harvester/sources/ProviderFetchVectorDatasetInitiator.java
@@ -12,7 +12,8 @@ import nl.idgis.publisher.provider.protocol.VectorDatasetInfo;
 
 public class ProviderFetchVectorDatasetInitiator extends ProviderFetchDatasetInitiator<FetchVectorDataset, VectorDatasetInfo> {
 	
-	private final int GET_VECTOR_DATASET_MESSAGE_SIZE = 100;
+	//private final int GET_VECTOR_DATASET_MESSAGE_SIZE = 100;
+	private final int GET_VECTOR_DATASET_MESSAGE_SIZE = 1;
 	
 	public ProviderFetchVectorDatasetInitiator(ActorRef sender, FetchVectorDataset request, ActorRef receiver, ActorRef provider) {
 		super(sender, request, receiver, provider);


### PR DESCRIPTION
known to be returned by SDE.ST_ASBINARY on empty geometries