### PR TITLE
Don't display removed datasets in service metadata

### DIFF
--- a/publisher-metadata/app/controllers/ServiceMetadata.java
+++ b/publisher-metadata/app/controllers/ServiceMetadata.java
@@ -156,7 +156,9 @@ public class ServiceMetadata extends AbstractMetadata {
 			}
 			
 			List<Tuple> serviceDatasetTuples = serviceDatasetQuery
-				.where(publishedServiceDataset.serviceId.eq(serviceId))
+				.join(sourceDataset).on(sourceDataset.id.eq(dataset.sourceDatasetId))
+				.where(publishedServiceDataset.serviceId.eq(serviceId)
+					.and(sourceDataset.deleteTime.isNull()))
 				.orderBy(dataset.id.asc(), publishedServiceDataset.layerName.asc())
 				.list(
 					dataset.id,


### PR DESCRIPTION
connects to IDgis/geoportaal-test#565