### PR TITLE
Update pg driver and move to postgres base image

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ ext {
 	jolokiaVersion = '1.3.7'
 	junitVersion = '4.11'
 	logbackVersion= '1.1.2'
-	postgresVersion = '42.2.18'
+	postgresVersion = '42.7.7'
 	querydslVersion = '3.4.1'
 	scalaAbiVersion = '2.11'
 }
@@ -511,29 +511,18 @@ project(':publisher-database') {
 	
 	task createDockerfile(type: Dockerfile) {
 		destFile = project.file("${project.buildDir}/docker/Dockerfile")
-		from 'ubuntu:xenial'
-		runCommand '''\
-			apt-get update && \
-			apt-get -qy install \
-				postgresql-9.5 \
-				postgresql-client-9.5 \
-				postgresql-9.5-postgis-2.2 && \
-			pg_dropcluster --stop 9.5 main && \
-			pg_createcluster --start -e UTF-8 9.5 main
-			'''
+		from 'postgres:17.6'
 		copyFile 'sql', '/opt/sql'
 		copyFile 'start.sh', '/opt/'
 		runCommand 'chmod a+x /opt/start.sh'
 		user 'postgres'
-		runCommand 'echo "host all all 0.0.0.0/0 md5" >> /etc/postgresql/9.5/main/pg_hba.conf'
-		runCommand 'echo "listen_addresses=\'*\'" >> /etc/postgresql/9.5/main/postgresql.conf'
-		environmentVariable 'PG_DATABASE', 'publisher'
-		environmentVariable 'PG_USER', 'publisher'
-		environmentVariable 'PG_PASSWORD', 'publisher'
-		environmentVariable 'PG_VERSION_SCHEMA', 'publisher'
-		environmentVariable 'PG_VERSION_TABLE', 'version'
-		exposePort 5432
-		defaultCommand '/bin/bash', '-c', '/opt/start.sh'
+		environmentVariable 'POSTGRES_DATABASE', 'publisher'
+		environmentVariable 'POSTGRES_USER', 'publisher'
+		environmentVariable 'POSTGRES_PASSWORD', 'publisher'
+		environmentVariable 'POSTGRES_VERSION_SCHEMA', 'publisher'
+		environmentVariable 'POSTGRES_VERSION_TABLE', 'version'
+		entryPoint '/bin/bash', '-c', '/opt/start.sh'
+		defaultCommand ''
 	}
 	
 	task pullUbuntuImage(type: DockerPullImage) {

--- a/publisher-database/src/main/bash/start.sh
+++ b/publisher-database/src/main/bash/start.sh
@@ -1,44 +1,27 @@
 #!/bin/bash
 
-sed -i 's/^#\?shared_buffers.*/shared_buffers = 2GB/g' /etc/postgresql/9.5/main/postgresql.conf
-sed -i 's/^#\?max_connections.*/max_connections = 300/g' /etc/postgresql/9.5/main/postgresql.conf
+set -eu
 
-set -e
+docker-entrypoint.sh postgres &
 
-echo "Starting PostgreSQL daemon ..."
-/etc/init.d/postgresql start
-
-sleep 5s
-
-# Create the database:
-RESULT=$(psql -l | grep "$PG_DATABASE" | wc -l)
-if [[ ${RESULT} != 1 ]]; then
-	echo "Creating database '$PG_DATABASE' with owner '$PG_USER' ..."
-	
-	# Create the user:
-	psql -c "create user $PG_USER with password '$PG_PASSWORD';"
-	psql -c "alter user $PG_USER with superuser;"
-	
-	# Create the database:
-	createdb -O $PG_USER -E UTF8 -T template0 $PG_DATABASE
-	psql -c "create extension postgis;" $PG_DATABASE
-else
-	echo "Database '$PG_DATABASE' exists."
-fi
+until psql -U $POSTGRES_USER -d $POSTGRES_DATABASE -c '\q' > /dev/null 2>&1; do
+    echo "Waiting for database to exist..."
+    sleep 1
+done
 
 # Determine current PostgreSQL version:
 echo "Determining current database revision ..."
 
-TABLE=$(psql -d $PG_DATABASE -At -c "select table_name from information_schema.tables where table_schema = '$PG_VERSION_SCHEMA' and table_name = '$PG_VERSION_TABLE';")
-if [[ "${TABLE}" != "$PG_VERSION_TABLE" ]]; then
-	echo "Version table $PG_VERSION_SCHEMA.$PG_VERSION_TABLE doesn't exist, starting at rev000 $TABLE"
+TABLE=$(psql -U $POSTGRES_USER -d $POSTGRES_DATABASE -At -c "select table_name from information_schema.tables where table_schema = '$POSTGRES_VERSION_SCHEMA' and table_name = '$POSTGRES_VERSION_TABLE';")
+if [[ "${TABLE}" != "$POSTGRES_VERSION_TABLE" ]]; then
+	echo "Version table $POSTGRES_VERSION_SCHEMA.$POSTGRES_VERSION_TABLE doesn't exist, starting at rev000 $TABLE"
 	VERSION=000
 else
-	VERSION_RAW=$(psql -d $PG_DATABASE -At -c "select max(id) from $PG_VERSION_SCHEMA.$PG_VERSION_TABLE")
+	VERSION_RAW=$(psql -U $POSTGRES_USER -d $POSTGRES_DATABASE -At -c "select max(id) from $POSTGRES_VERSION_SCHEMA.$POSTGRES_VERSION_TABLE")
 	VERSION_START=$(($VERSION_RAW+1))
 	VERSION=$(printf "%03d" $VERSION_START)
 
-	echo "Version table $PG_VERSION_SCHEMA.$PG_VERSION_TABLE exists, starting at rev$VERSION"
+	echo "Version table $POSTGRES_VERSION_SCHEMA.$POSTGRES_VERSION_TABLE exists, starting at rev$VERSION"
 fi
 
 
@@ -62,12 +45,11 @@ for file in /opt/sql/rev*.sql; do
 done
 echo "commit;" >> /tmp/patch.sql
 
-psql -d $PG_DATABASE -v ON_ERROR_STOP=1 -f /tmp/patch.sql
+psql -U $POSTGRES_USER -d $POSTGRES_DATABASE -v ON_ERROR_STOP=1 -f /tmp/patch.sql
 
-echo "Stopping PostgreSQL daemon ..."
-/etc/init.d/postgresql stop
+sed -i "s/^#*max_connections.*/max_connections = 200/" "$PGDATA/postgresql.conf"
+sed -i "s/^#*shared_buffers.*/shared_buffers = 2GB/" "$PGDATA/postgresql.conf"
 
-# Run PostgreSQL:
-echo "Starting PostgreSQL in foreground mode ..."
-exec /usr/lib/postgresql/9.5/bin/postgres -D /var/lib/postgresql/9.5/main \
-    -c config_file=/etc/postgresql/9.5/main/postgresql.conf
+pg_ctl -D "$PGDATA" -m fast stop
+
+exec docker-entrypoint.sh postgres


### PR DESCRIPTION
- Upgrade van postgres driver
- Migratie naar postgres base image waarmee de gebruiker en database vanzelf aangemaakt worden (vandaar de verandering van de `PG_` omgevingsvariabelen naar `POSTGRES_`
- De release moet direct uitgerold worden nadat de data gemigreerd is